### PR TITLE
Add example config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@
 
 /.idea/
 /node_modules/
-/elm-stuff/
+elm-stuff

--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 # review-noregex
-Provides [elm-review](https://package.elm-lang.org/packages/jfmengels/elm-review/latest/) rule to forbid regex usage.
+
+Provides [elm-review][elm-review] rule to forbid Regex usage.
 
 ## Usage
-After adding [elm-review](https://package.elm-lang.org/packages/jfmengels/elm-review/latest/) to your project, import this rule to
-`ReviewConfig.elm` file and add it to the config. 
+
+After adding [elm-review][elm-review] to your project, import this rule to `ReviewConfig.elm` file and add it to the config.
 
 ## Example configuration
-    import NoRegex
-    import Review.Rule exposing (Rule)
 
-    config : List Rule
-    config =
-        [ NoRegex.rule ]
+```elm
+import NoRegex
+import Review.Rule exposing (Rule)
+
+config : List Rule
+config =
+    [ NoRegex.rule ]
+```
+
+
+[elm-review]: https://package.elm-lang.org/packages/jfmengels/elm-review/latest/

--- a/example/elm.json
+++ b/example/elm.json
@@ -1,0 +1,38 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "ContaSystemer/review-noregex": "1.0.1",
+            "elm/core": "1.0.5",
+            "jfmengels/elm-review": "2.2.0"
+        },
+        "indirect": {
+            "elm/browser": "1.0.2",
+            "elm/html": "1.0.0",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/project-metadata-utils": "1.0.1",
+            "elm/random": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.2",
+            "elm-community/json-extra": "4.3.0",
+            "elm-community/list-extra": "8.2.4",
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-hex": "1.0.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3",
+            "stil4m/elm-syntax": "7.1.3",
+            "stil4m/structured-writer": "1.0.3"
+        }
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.2.2"
+        },
+        "indirect": {}
+    }
+}

--- a/example/src/ReviewConfig.elm
+++ b/example/src/ReviewConfig.elm
@@ -1,0 +1,21 @@
+module ReviewConfig exposing (config)
+
+{-| Do not rename the ReviewConfig module or the config function, because
+`elm-review` will look for these.
+
+To add packages that contain rules, add them to this review project using
+
+    `elm install author/packagename`
+
+when inside the directory containing this file.
+
+-}
+
+import NoRegex
+import Review.Rule exposing (Rule)
+
+
+config : List Rule
+config =
+    [ NoRegex.rule
+    ]


### PR DESCRIPTION
Add an `example/` config ready for [elm-review@2.3.0](https://github.com/jfmengels/node-elm-review/releases/tag/v2.3.0-beta.1)'s upcoming `--template` feature. (No new version is needed for this to work)